### PR TITLE
feat: add dutch translations, fix: foxclient settings sidebar width, ON/OFF toggle will now respect game language

### DIFF
--- a/src/main/java/net/foxes4life/foxclient/screen/settings/FoxClientSettingsScreen.java
+++ b/src/main/java/net/foxes4life/foxclient/screen/settings/FoxClientSettingsScreen.java
@@ -39,7 +39,7 @@ public class FoxClientSettingsScreen extends Screen {
     static double entryHoverBgY = 0;
     static int entryHoverBgYGoal = 0;
 
-    private static final int sidebarWidth = 64 + 16;
+    private static final int sidebarWidth = 64 + 32;
 
     private int amountOfDrawableChilds = 0; // set amount of buttons created in init() here (excluding the ones in the loop)
     private boolean initDone = false; // to prevent amountOfDrawableChilds from increasing after init is done

--- a/src/main/java/net/foxes4life/foxclient/screen/settings/ui/ToggleButton.java
+++ b/src/main/java/net/foxes4life/foxclient/screen/settings/ui/ToggleButton.java
@@ -4,6 +4,7 @@ import net.foxes4life.foxclient.ui.button.FoxClientButton;
 import net.foxes4life.foxclient.util.TextUtils;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.resource.language.I18n;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.MathHelper;
@@ -36,7 +37,8 @@ public class ToggleButton extends FoxClientButton {
             text_alpha = 0.75f;
         }
 
-        String text = getMessage().getString() + ": " + (displayValue ? "§aON" : "§cOFF");
+        String text = getMessage().getString() + ": " + (displayValue ? "§a" + I18n.translate("foxclient.config.toggle.on") : "§c" + I18n.translate("foxclient.config.toggle.off"));
+
 
         drawCenteredTextWithShadow(matrices, textRenderer, TextUtils.string(text),
                 this.getX() + this.width / 2,

--- a/src/main/resources/assets/minecraft/lang/de_de.json
+++ b/src/main/resources/assets/minecraft/lang/de_de.json
@@ -53,5 +53,8 @@
 
   "foxclient.config.discordenabled": "DiscordRPC - Eingeschaltet",
   "foxclient.config.discordshowip": "DiscordRPC - IP anzeigen",
-  "foxclient.config.discordshowplayer": "DiscordRPC - Eigenen Spieler anzeigen"
+  "foxclient.config.discordshowplayer": "DiscordRPC - Eigenen Spieler anzeigen",
+
+  "foxclient.config.toggle.on": "AN",
+  "foxclient.config.toggle.off": "AUS"
 }

--- a/src/main/resources/assets/minecraft/lang/en_us.json
+++ b/src/main/resources/assets/minecraft/lang/en_us.json
@@ -53,5 +53,8 @@
 
   "foxclient.config.discordenabled": "DiscordRPC - Enabled",
   "foxclient.config.discordshowip": "DiscordRPC - Show IP",
-  "foxclient.config.discordshowplayer": "DiscordRPC - Show own player"
+  "foxclient.config.discordshowplayer": "DiscordRPC - Show own player",
+
+  "foxclient.config.toggle.on": "ON",
+  "foxclient.config.toggle.off": "OFF"
 }

--- a/src/main/resources/assets/minecraft/lang/nl_nl.json
+++ b/src/main/resources/assets/minecraft/lang/nl_nl.json
@@ -1,0 +1,57 @@
+{
+  "title.multiplayer.other2": "Meerspeler (%s)",
+
+  "foxclient.gui.button.reconnect": "Maak opnieuw verbinding",
+  "foxclient.gui.button.close": "Sluiten",
+
+  "foxclient.gui.toast.title": "FoxClient",
+  "foxclient.gui.toast.modmenu.missing": "ModMenu is niet geïnstalleerd",
+
+  "category.foxclient.main": "FoxClient",
+  "key.foxclient.toggle_hud": "Schakel HUD in/uit schakelen",
+  "key.foxclient.freelook": "Freelook",
+  "key.foxclient.configKey": "FoxClient Konfiguratie",
+  "key.foxclient.zoom": "Zoom",
+
+  "foxclient.rpc.state.idle": "Inactief",
+  "foxclient.rpc.state.singleplayer": "Speelt een speler",
+  "foxclient.rpc.state.lan": "Speelt in een LAN-game",
+  "foxclient.rpc.state.multiplayer": "Speelt op %s",
+  "foxclient.rpc.state.multiplayer.count": "Speelt op %s (%s speler)",
+  "foxclient.rpc.state.multiplayer.count.single": "Speelt op %s (%s spelers)",
+  "foxclient.rpc.state.multiplayer.hide_ip": "Speelt meerspeler",
+  "foxclient.rpc.state.realms": "Speelt op een Realm",
+
+  "foxclient.config.category.ingame-hud": "In-Game HUD",
+  "foxclient.config.category.armor-hud": "Pantser HUD",
+  "foxclient.config.category.client": "Cliënt",
+  "foxclient.config.category.eastereggs": "EasterEggs",
+  "foxclient.config.category.menus": "Aangepaste menu's",
+  "foxclient.config.category.misc": "Miscellaneous",
+
+  "foxclient.config.smoothzoom": "Smooth Zoom in/uit schakelen",
+
+  "foxclient.config.hudenabled" : "In-Game HUD in/uit schakelen",
+  "foxclient.config.hudping": "Ping",
+  "foxclient.config.hudtps": "TPS",
+  "foxclient.config.hudfps": "FPS",
+  "foxclient.config.hudversion": "Versie",
+  "foxclient.config.hudcoordinates": "XYZ",
+  "foxclient.config.hudbiome": "Bioom",
+  "foxclient.config.hudcoordinatescolor": "Gekleurde XYZ",
+  "foxclient.config.hudserverip": "Server IP",
+  "foxclient.config.hudlogo": "Logo",
+  "foxclient.config.hudbackground": "Achtergrond",
+
+  "foxclient.config.armorhudenabled": "Pantser HUD in/uit schakelen",
+  "foxclient.config.armorhuddisplaypercentage": "Weergeven als percentage",
+
+  "foxclient.config.uwufy": "UwUfy",
+
+  "foxclient.config.custommainmenu": "Hoofdmenu",
+  "foxclient.config.custompausemenu": "Pauzemenu",
+
+  "foxclient.config.discordenabled": "DiscordRPC - in/uit schakelen",
+  "foxclient.config.discordshowip": "DiscordRPC - IP weergeven",
+  "foxclient.config.discordshowplayer": "DiscordRPC - toon eigen speeler"
+}

--- a/src/main/resources/assets/minecraft/lang/nl_nl.json
+++ b/src/main/resources/assets/minecraft/lang/nl_nl.json
@@ -8,18 +8,18 @@
   "foxclient.gui.toast.modmenu.missing": "ModMenu is niet geïnstalleerd",
 
   "category.foxclient.main": "FoxClient",
-  "key.foxclient.toggle_hud": "Schakel HUD in/uit schakelen",
+  "key.foxclient.toggle_hud": "HUD in/uit schakelen",
   "key.foxclient.freelook": "Freelook",
-  "key.foxclient.configKey": "FoxClient Konfiguratie",
+  "key.foxclient.configKey": "FoxClient Configuratie",
   "key.foxclient.zoom": "Zoom",
 
   "foxclient.rpc.state.idle": "Inactief",
-  "foxclient.rpc.state.singleplayer": "Speelt een speler",
+  "foxclient.rpc.state.singleplayer": "Speelt singleplayer",
   "foxclient.rpc.state.lan": "Speelt in een LAN-game",
   "foxclient.rpc.state.multiplayer": "Speelt op %s",
   "foxclient.rpc.state.multiplayer.count": "Speelt op %s (%s speler)",
   "foxclient.rpc.state.multiplayer.count.single": "Speelt op %s (%s spelers)",
-  "foxclient.rpc.state.multiplayer.hide_ip": "Speelt meerspeler",
+  "foxclient.rpc.state.multiplayer.hide_ip": "Speelt multiplayer",
   "foxclient.rpc.state.realms": "Speelt op een Realm",
 
   "foxclient.config.category.ingame-hud": "In-Game HUD",
@@ -27,7 +27,7 @@
   "foxclient.config.category.client": "Cliënt",
   "foxclient.config.category.eastereggs": "EasterEggs",
   "foxclient.config.category.menus": "Aangepaste menu's",
-  "foxclient.config.category.misc": "Miscellaneous",
+  "foxclient.config.category.misc": "Overige",
 
   "foxclient.config.smoothzoom": "Smooth Zoom in/uit schakelen",
 
@@ -53,7 +53,7 @@
 
   "foxclient.config.discordenabled": "DiscordRPC - in/uit schakelen",
   "foxclient.config.discordshowip": "DiscordRPC - IP weergeven",
-  "foxclient.config.discordshowplayer": "DiscordRPC - toon eigen speeler",
+  "foxclient.config.discordshowplayer": "DiscordRPC - toon eigen speler",
 
   "foxclient.config.toggle.on": "AAN",
   "foxclient.config.toggle.off": "UIT"

--- a/src/main/resources/assets/minecraft/lang/nl_nl.json
+++ b/src/main/resources/assets/minecraft/lang/nl_nl.json
@@ -53,5 +53,8 @@
 
   "foxclient.config.discordenabled": "DiscordRPC - in/uit schakelen",
   "foxclient.config.discordshowip": "DiscordRPC - IP weergeven",
-  "foxclient.config.discordshowplayer": "DiscordRPC - toon eigen speeler"
+  "foxclient.config.discordshowplayer": "DiscordRPC - toon eigen speeler",
+
+  "foxclient.config.toggle.on": "AAN",
+  "foxclient.config.toggle.off": "UIT"
 }


### PR DESCRIPTION
the foxclient sidebar width needed to be increased, because with the current width, some text will go off screen/off the sidebar, when set to as an example dutch (could also happen with other languages). It's very possible that the dutch translations are not 100% correct, but they should be good enough.